### PR TITLE
Allow multiple correct answers for "radio" type questions

### DIFF
--- a/src/quizlib.js
+++ b/src/quizlib.js
@@ -157,6 +157,7 @@ Quiz.prototype.checkAnswers = function(flagUnanswered) {
 				userAnswer.push(input.value);
 			}
 		}
+				
 		// Remove single answer from array to match provided answer format
 		if (userAnswer.length == 1 && !Array.isArray(answer)) {
 			userAnswer = userAnswer[0];
@@ -164,7 +165,25 @@ Quiz.prototype.checkAnswers = function(flagUnanswered) {
 			unansweredQs.push(question);
 		}
 		
-		questionResults.push(Utils.compare(userAnswer, answer));
+		// Check the answers.
+		// For single-choice questions, one correct answer must be given (out of perhaps multiple correct ones).
+		if (input.type === "radio") {
+			// Remove the single answer from its array, if it's still in there.
+			if (Array.isArray(userAnswer) && userAnswer.length == 1) {
+				userAnswer = userAnswer[0];
+			}
+		
+			if (Array.isArray(answer)) {
+				questionResults.push(answer.indexOf(userAnswer) >= 0);
+			}
+			else {
+				questionResults.push(userAnswer === answer);
+			}
+		}
+		// For multiple-choice questions (type "checkbox") and free-text questions, all correct answers must be given.
+		else {
+			questionResults.push(Utils.compare(userAnswer, answer));
+		}
 	}
 
 	if (unansweredQs.length === 0 || !flagUnanswered) {


### PR DESCRIPTION
We had a usecase where a single-choice question (using radiobuttons) had multiple correct answer options, and the user (obviously) had to choose one of them to pass that question. This PR implements this.

The previous mode of specifying one correct answer for a radiobutton-type question is still possible, so this PR is backwards compatible.

Additionally, when clicking "Check Answers" and the answers are highlighted, this new mechanism would profit from highlighting all correct answers to a radiobutton type question even if a correct answer was chosen (so users can resolve the doubts they had when choosing an answer). I didn't implement that, though.